### PR TITLE
 Add MinatarCNN Architecture to Torch Base Models

### DIFF
--- a/rlberry_research/agents/torch/utils/models.py
+++ b/rlberry_research/agents/torch/utils/models.py
@@ -540,13 +540,14 @@ class ConvolutionalNetwork(nn.Module):
     def action_scores(self, x):
         return self.head.action_scores(self.convolutions(x))
 
+
 class MinatarCNN(nn.Module):
     """
     CNN from MinAtar  paper:
         Young, Kenny & Tian, Tian. (2019).
-        MinAtar: An Atari-inspired Testbed for 
+        MinAtar: An Atari-inspired Testbed for
         More Efficient Reinforcement Learning Experiments.
-        10.48550/arXiv.1903.03176. 
+        10.48550/arXiv.1903.03176.
 
     Expects inputs of shape BCHW, where
     B = batch size;
@@ -573,6 +574,7 @@ class MinatarCNN(nn.Module):
         :func:`~rlberry_research.agents.torch.utils.training.model_factory`
 
     """
+
     def __init__(
         self,
         activation="RELU",
@@ -642,9 +644,7 @@ class MinatarCNN(nn.Module):
             x = x.view(inputview_size)
 
         conv_result = self.convolutions(x)
-        output_result = self.head(
-            conv_result.view(conv_result.size()[0], -1)
-        )
+        output_result = self.head(conv_result.view(conv_result.size()[0], -1))
 
         if flag_view_to_change:
             output_result = output_result.view(outputview_size)

--- a/rlberry_research/agents/torch/utils/training.py
+++ b/rlberry_research/agents/torch/utils/training.py
@@ -76,7 +76,7 @@ def model_factory(type="MultiLayerPerceptron", **kwargs) -> nn.Module:
         * :class:`~rlberry_research.agents.torch.utils.models.ConvolutionalNetwork`
 
         * :class:`~rlberry_research.agents.torch.utils.models.DuelingNetwork`
-        
+
         * :class:`~rlberry_research.agents.torch.utils.models.MinatarCNN`
 
         * :class:`~rlberry_research.agents.torch.utils.models.Table`

--- a/rlberry_research/agents/torch/utils/training.py
+++ b/rlberry_research/agents/torch/utils/training.py
@@ -76,6 +76,8 @@ def model_factory(type="MultiLayerPerceptron", **kwargs) -> nn.Module:
         * :class:`~rlberry_research.agents.torch.utils.models.ConvolutionalNetwork`
 
         * :class:`~rlberry_research.agents.torch.utils.models.DuelingNetwork`
+        
+        * :class:`~rlberry_research.agents.torch.utils.models.MinatarCNN`
 
         * :class:`~rlberry_research.agents.torch.utils.models.Table`
     """
@@ -83,6 +85,7 @@ def model_factory(type="MultiLayerPerceptron", **kwargs) -> nn.Module:
         MultiLayerPerceptron,
         DuelingNetwork,
         ConvolutionalNetwork,
+        MinatarCNN,
         Table,
     )
 
@@ -90,6 +93,8 @@ def model_factory(type="MultiLayerPerceptron", **kwargs) -> nn.Module:
         return MultiLayerPerceptron(**kwargs)
     elif type == "DuelingNetwork":
         return DuelingNetwork(**kwargs)
+    elif type == "MinatarCNN":
+        return MinatarCNN(**kwargs)
     elif type == "ConvolutionalNetwork":
         return ConvolutionalNetwork(**kwargs)
     elif type == "Table":


### PR DESCRIPTION

## Description
The current ConvolutionalNetwork class lacks flexibility, making it challenging to adjust parameters like the number of convolutions, kernel sizes, etc.

This PR introduces a lightweight MinatarCNN architecture tailored for Minatar environments. It serves as a smaller, more efficient alternative to the existing network.

Future Work:
Further enhancements to the base ConvolutionalNetwork class can provide more configurability and better support for diverse use cases.

<!---
## Checklist
- \[x] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[x] I have commented my code, particularly in hard-to-understand areas,
- \[x] I have made corresponding changes to the documentation,
- \[x] I have added tests that prove my fix is effective or that my feature works,
- \[x] New and existing unit tests pass locally with my changes,
- \[x] If updated the changelog if necessary,
- \[x] I have set the label "ready for review" and the checks are all green.
-->
